### PR TITLE
Add ProTx RPC calls

### DIFF
--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -65,4 +65,8 @@ fn main() {
     // Get Quorum sign
     let quorum_sign = rpc.get_quorum_sign(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239", None, None).unwrap();
     println!("\nQuorum sign: \n{:?}", quorum_sign);
+
+    // Get Quorum GetRecSig
+    let quorum_getrecsig = rpc.get_quorum_getrecsig(1, "e980ebf295b42f24b03321ffb255818753b2b211e8c46b61c0b6fde91242d12f", "907087d4720850e639b7b5cc41d7a6d020e5a50debb3bc3974f0cb3d7d378ea4").unwrap();
+    println!("\nQuorum getrecsig: \n{:?}", quorum_getrecsig);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -101,4 +101,8 @@ fn main() {
     // Get Protx info
     let protx_info = rpc.get_protx_info("000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f").unwrap();
     println!("\nProtx info: \n{:?}", protx_info);
+
+    // Get Protx list
+    let protx_list = rpc.get_protx_list(Some("valid"), Some(true), Some(7090)).unwrap();
+    println!("\nProtx list: \n{:?}", protx_list);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -55,11 +55,14 @@ fn main() {
     println!("\nQuorum list: \n{:?}", quorum_list);
 
     // Get Quorum info
-    let quorum_info = rpc.get_quorum_info("1", "000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f", None).unwrap();
+    let quorum_info = rpc.get_quorum_info(1, "000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f", None).unwrap();
     println!("\nQuorum info: \n{:?}", quorum_info);
 
     // Get Quorum DKG status
     let quorum_dkgstatus = rpc.get_quorum_dkgstatus(None).unwrap();
-    println!("\nQuorum list: \n{:?}", quorum_dkgstatus);
+    println!("\nQuorum dkg status: \n{:?}", quorum_dkgstatus);
 
+    // Get Quorum sign
+    let quorum_sign = rpc.get_quorum_sign(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239", None, None).unwrap();
+    println!("\nQuorum sign: \n{:?}", quorum_sign);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -81,4 +81,12 @@ fn main() {
     // Get Quorum memberof
     let quorum_memberof = rpc.get_quorum_memberof("39c07d2c9c6d0ead56f52726b63c15e295cb5c3ecf7fe1fefcfb23b2e3cfed1f", Some(1)).unwrap();
     println!("\nQuorum memberof: \n{:?}", quorum_memberof);
+
+    // Get Quorum rotationinfo
+    let quorum_rotationinfo = rpc.get_quorum_rotationinfo("0000012197b7ca6360af3756c6a49c217dbbdf8b595fd55e0fcef7ffcd546044", None, None).unwrap();
+    println!("\nQuorum rotationinfo: \n{:?}", quorum_rotationinfo);
+
+    // Get Quorum selectquorum
+    let quorum_selectquorum = rpc.get_quorum_selectquorum(1, "b95205c3bba72e9edfbe7380ec91fe5a97e16a189e28f39b03c6822757ad1a34").unwrap();
+    println!("\nQuorum selectquorum: \n{:?}", quorum_selectquorum);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -105,4 +105,8 @@ fn main() {
     // Get Protx list
     let protx_list = rpc.get_protx_list(Some("valid"), Some(true), Some(7090)).unwrap();
     println!("\nProtx list: \n{:?}", protx_list);
+
+    // Get Protx register
+    let protx_register = rpc.get_protx_register("8b2eab3413abb6e04d17d1defe2b71039ba6b6f72ea1e5dab29bb10e7b745948", 1, "2.3.4.5:2345", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", "88d719278eef605d9c19037366910b59bc28d437de4a8db4d76fda6d6985dbdf10404fb9bb5cd0e8c22f4a914a6c5566", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", 5, "yjJJLkYDUN6X8gWjXbCoKEXoiLeKxxMMRt", None, Some(false)).unwrap();
+    println!("\nProtx list: \n{:?}", protx_register);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -93,4 +93,8 @@ fn main() {
     // Get Quorum verify
     let quorum_verify = rpc.get_quorum_verify(1, "2ceeaa7ff20de327ef65b14de692199d15b67b9458d0ded7d68735cce98dd039", "8b5174d0e95b5642ebec23c3fe8f0bbf8f6993502f4210322871bba0e818ff3b", "99cf2a0deb08286a2d1ffdd2564b35522fd748c8802e561abed330dea20df5cb5a5dffeddbe627ea32cb36de13d5b4a516fdfaebae9886b2f7969a5d112416cf8d1983ebcbf1463a64f7522505627e08b9c76c036616fbb1649271a2773a1653", Some("000000583a348d1a0a5f753ef98e6a69f9bcd9b27919f10eb1a1c3edb6c79182"), None).unwrap();
     println!("\nQuorum verify: \n{:?}", quorum_verify);
+
+    // Get Protx diff
+    let protx_diff = rpc.get_protx_diff(75000, 76000).unwrap();
+    println!("\nProtx diff: \n{:?}", protx_diff);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -89,4 +89,8 @@ fn main() {
     // Get Quorum selectquorum
     let quorum_selectquorum = rpc.get_quorum_selectquorum(1, "b95205c3bba72e9edfbe7380ec91fe5a97e16a189e28f39b03c6822757ad1a34").unwrap();
     println!("\nQuorum selectquorum: \n{:?}", quorum_selectquorum);
+
+    // Get Quorum verify
+    let quorum_verify = rpc.get_quorum_verify(1, "2ceeaa7ff20de327ef65b14de692199d15b67b9458d0ded7d68735cce98dd039", "8b5174d0e95b5642ebec23c3fe8f0bbf8f6993502f4210322871bba0e818ff3b", "99cf2a0deb08286a2d1ffdd2564b35522fd748c8802e561abed330dea20df5cb5a5dffeddbe627ea32cb36de13d5b4a516fdfaebae9886b2f7969a5d112416cf8d1983ebcbf1463a64f7522505627e08b9c76c036616fbb1649271a2773a1653", Some("000000583a348d1a0a5f753ef98e6a69f9bcd9b27919f10eb1a1c3edb6c79182"), None).unwrap();
+    println!("\nQuorum verify: \n{:?}", quorum_verify);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -59,7 +59,7 @@ fn main() {
     println!("\nQuorum info: \n{:?}", quorum_info);
 
     // Get Quorum DKG status
-    let quorum_dkgstatus = rpc.get_quorum_dkgstatus().unwrap();
+    let quorum_dkgstatus = rpc.get_quorum_dkgstatus(None).unwrap();
     println!("\nQuorum list: \n{:?}", quorum_dkgstatus);
 
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -50,4 +50,16 @@ fn main() {
     let mn_winners = rpc.get_masternode_winners(None, None).unwrap();
     println!("\n\nMasternode Winners: \n{:?}", mn_winners);
 
+    // Get Quorum list
+    let quorum_list = rpc.get_quorum_list(None).unwrap();
+    println!("\nQuorum list: \n{:?}", quorum_list);
+
+    // Get Quorum info
+    let quorum_info = rpc.get_quorum_info("1", "000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f", None).unwrap();
+    println!("\nQuorum info: \n{:?}", quorum_info);
+
+    // Get Quorum DKG status
+    let quorum_dkgstatus = rpc.get_quorum_dkgstatus().unwrap();
+    println!("\nQuorum list: \n{:?}", quorum_dkgstatus);
+
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -77,4 +77,8 @@ fn main() {
     // Get Quorum isconflicting
     let quorum_isconflicting = rpc.get_quorum_isconflicting(1, "e980ebf295b42f24b03321ffb255818753b2b211e8c46b61c0b6fde91242d12f", "907087d4720850e639b7b5cc41d7a6d020e5a50debb3bc3974f0cb3d7d378ea4").unwrap();
     println!("\nQuorum isconflicting: \n{:?}", quorum_isconflicting);
+
+    // Get Quorum memberof
+    let quorum_memberof = rpc.get_quorum_memberof("39c07d2c9c6d0ead56f52726b63c15e295cb5c3ecf7fe1fefcfb23b2e3cfed1f", Some(1)).unwrap();
+    println!("\nQuorum memberof: \n{:?}", quorum_memberof);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -97,4 +97,8 @@ fn main() {
     // Get Protx diff
     let protx_diff = rpc.get_protx_diff(75000, 76000).unwrap();
     println!("\nProtx diff: \n{:?}", protx_diff);
+
+    // Get Protx info
+    let protx_info = rpc.get_protx_info("000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f").unwrap();
+    println!("\nProtx info: \n{:?}", protx_info);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -69,4 +69,12 @@ fn main() {
     // Get Quorum GetRecSig
     let quorum_getrecsig = rpc.get_quorum_getrecsig(1, "e980ebf295b42f24b03321ffb255818753b2b211e8c46b61c0b6fde91242d12f", "907087d4720850e639b7b5cc41d7a6d020e5a50debb3bc3974f0cb3d7d378ea4").unwrap();
     println!("\nQuorum getrecsig: \n{:?}", quorum_getrecsig);
+
+    // Get Quorum HasRecSig
+    let quorum_hasrecsig = rpc.get_quorum_hasrecsig(1, "e980ebf295b42f24b03321ffb255818753b2b211e8c46b61c0b6fde91242d12f", "907087d4720850e639b7b5cc41d7a6d020e5a50debb3bc3974f0cb3d7d378ea4").unwrap();
+    println!("\nQuorum hasrecsig: \n{:?}", quorum_hasrecsig);
+
+    // Get Quorum isconflicting
+    let quorum_isconflicting = rpc.get_quorum_isconflicting(1, "e980ebf295b42f24b03321ffb255818753b2b211e8c46b61c0b6fde91242d12f", "907087d4720850e639b7b5cc41d7a6d020e5a50debb3bc3974f0cb3d7d378ea4").unwrap();
+    println!("\nQuorum isconflicting: \n{:?}", quorum_isconflicting);
 }

--- a/client/examples/connect_to_masternode.rs
+++ b/client/examples/connect_to_masternode.rs
@@ -109,4 +109,8 @@ fn main() {
     // Get Protx register
     let protx_register = rpc.get_protx_register("8b2eab3413abb6e04d17d1defe2b71039ba6b6f72ea1e5dab29bb10e7b745948", 1, "2.3.4.5:2345", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", "88d719278eef605d9c19037366910b59bc28d437de4a8db4d76fda6d6985dbdf10404fb9bb5cd0e8c22f4a914a6c5566", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", 5, "yjJJLkYDUN6X8gWjXbCoKEXoiLeKxxMMRt", None, Some(false)).unwrap();
     println!("\nProtx list: \n{:?}", protx_register);
+
+    // Get Protx register_fund
+    let protx_register_fund = rpc.get_protx_register_fund("yakx4mMRptKhgfjedNzX5FGQq7kSSBF2e7", "3.4.5.6:3456", "yURczr3qY31xkQZfFu8eZvKz19eAEPQxsd", "0e02146e9c34cfbcb3f3037574a1abb35525e2ca0c3c6901dbf82ac591e30218d1711223b7ca956edf39f3d984d06d51", "yURczr3qY31xkQZfFu8eZvKz19eAEPQxsd", 5, "yUYTxqjpCfAAK4vgxXtBPywRBtZqsxN7Vy", Some("yRMFHxcJ2aS2vfo5whhE2Gg73dfQVm8LAF"), Some(false)).unwrap();
+    println!("\nProtx list: \n{:?}", protx_register_fund);
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1203,29 +1203,34 @@ pub trait RpcApi: Sized {
     // -------------------------- Quorum -------------------------------
 
     /// Returns a list of on-chain quorums
-    fn get_quorum_list(&self, count: Option<u32>) -> Result<json::QuorumListResult> {
+    fn get_quorum_list(&self, count: Option<u8>) -> Result<json::QuorumListResult> {
             let mut args = ["list".into(), opt_into_json(count)?];
             self.call::<json::QuorumListResult>("quorum", handle_defaults(&mut args, &[1.into(), null()]))
     }
 
     /// Returns information about a specific quorum
-    fn get_quorum_info(&self, llmq_type: u32, quorum_hash: &str, include_sk_share: Option<bool>) -> Result<json::QuorumInfoResult> {
+    fn get_quorum_info(&self, llmq_type: u8, quorum_hash: &str, include_sk_share: Option<bool>) -> Result<json::QuorumInfoResult> {
             let mut args = ["info".into(), into_json(llmq_type)?, into_json(quorum_hash)?, opt_into_json(include_sk_share)?];
             self.call::<json::QuorumInfoResult>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
     /// Returns the status of the current DKG process
-    fn get_quorum_dkgstatus(&self, detail_level: Option<u32>) -> Result<json::QuorumDKGStatus> {
+    fn get_quorum_dkgstatus(&self, detail_level: Option<u8>) -> Result<json::QuorumDKGStatus> {
            let mut args = ["dkgstatus".into(), opt_into_json(detail_level)?];
            self.call::<json::QuorumDKGStatus>("quorum", handle_defaults(&mut args, &[0.into(), null()]))
     }  
 
-    /// Requests threshold-signing for a message.
-    fn get_quorum_sign(&self, llmq_type: u32, id: &str, msg_hash: &str, quorum_hash: Option<&str>, submit: Option<bool>) -> Result<json::QuorumSignResult> {
+    /// Requests threshold-signing for a message
+    fn get_quorum_sign(&self, llmq_type: u8, id: &str, msg_hash: &str, quorum_hash: Option<&str>, submit: Option<bool>) -> Result<json::QuorumSignResult> {
             let mut args = ["sign".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?, opt_into_json(quorum_hash)?, opt_into_json(submit)?];
             self.call::<json::QuorumSignResult>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Returns the recovered signature for a previous threshold-signing message request
+    fn get_quorum_getrecsig(&self, llmq_type: u8, id: &str, msg_hash: &str) -> Result<json::QuorumSignature> {
+        let mut args = ["getrecsig".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?];
+        self.call::<json::QuorumSignature>("quorum", handle_defaults(&mut args, &[null()]))
+    }
 
 }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1232,6 +1232,12 @@ pub trait RpcApi: Sized {
         self.call::<json::QuorumSignature>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Returns the status of a recovered signature for a previous threshold-signing message request
+    fn get_quorum_hasrecsig(&self, llmq_type: u8, id: &str, msg_hash: &str) -> Result<bool> {
+        let mut args = ["getrecsig".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?];
+        self.call::<bool>("quorum", handle_defaults(&mut args, &[null()]))
+    }
+
 }
 
 /// Client implements a JSON-RPC client for the Dash Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1200,6 +1200,21 @@ pub trait RpcApi: Sized {
     }
 
 
+    // -------------------------- Quorum -------------------------------
+
+    /// Returns a list of on-chain quorums
+    fn get_quorum_list(&self, count: Option<&str>) -> Result<HashMap<String, Vec<String>>> {
+            let mut args = ["list".into(), opt_into_json(count)?];
+            self.call::<HashMap<String, Vec<String>>>("quorum", handle_defaults(&mut args, &["1".into(), null()]))
+    }
+
+    /// Returns information about a specific quorum
+    fn get_quorum_info(&self, llmq_type: &str, quorum_hash: &str, include_sk_share: Option<bool>) -> Result<json::QuorumInfoResult> {
+            let mut args = ["info".into(), into_json(llmq_type)?, into_json(quorum_hash)?, opt_into_json(include_sk_share)?];
+            self.call::<json::QuorumInfoResult>("quorum", handle_defaults(&mut args, &[null()]))
+    }
+
+
 }
 
 /// Client implements a JSON-RPC client for the Dash Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1232,9 +1232,15 @@ pub trait RpcApi: Sized {
         self.call::<json::QuorumSignature>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
-    /// Returns the status of a recovered signature for a previous threshold-signing message request
+    /// Checks for a recovered signature for a previous threshold-signing message request
     fn get_quorum_hasrecsig(&self, llmq_type: u8, id: &str, msg_hash: &str) -> Result<bool> {
-        let mut args = ["getrecsig".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?];
+        let mut args = ["hasrecsig".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?];
+        self.call::<bool>("quorum", handle_defaults(&mut args, &[null()]))
+    }
+
+    /// Checks if there is a conflict for a threshold-signing message request
+    fn get_quorum_isconflicting(&self, llmq_type: u8, id: &str, msg_hash: &str) -> Result<bool> {
+        let mut args = ["isconflicting".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?];
         self.call::<bool>("quorum", handle_defaults(&mut args, &[null()]))
     }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1283,6 +1283,12 @@ pub trait RpcApi: Sized {
         self.call::<json::ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Returns a list of provider transactions
+    fn get_protx_list(&self, protx_type: Option<&str>, detailed: Option<bool>, height: Option<u32>) -> Result<json::ProTxList> {
+            let mut args = ["list".into(), opt_into_json(protx_type)?, opt_into_json(detailed)?, opt_into_json(height)?];
+            self.call::<json::ProTxList>("protx", handle_defaults(&mut args, &[null()]))
+    }
+
 }
 
 /// Client implements a JSON-RPC client for the Dash Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1277,6 +1277,12 @@ pub trait RpcApi: Sized {
         self.call::<json::MasternodeListDiff>("protx", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Returns a returns detailed information about a deterministic masternode
+    fn get_protx_info(&self, protx_hash: &str) -> Result<json::ProTxInfo> {
+        let mut args = ["info".into(), into_json(protx_hash)?];
+        self.call::<json::ProTxInfo>("protx", handle_defaults(&mut args, &[null()]))
+    }
+
 }
 
 /// Client implements a JSON-RPC client for the Dash Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1268,6 +1268,14 @@ pub trait RpcApi: Sized {
             self.call::<bool>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
+    
+    // --------------------------- ProTx -------------------------------
+   
+    /// Returns a diff and a proof between two masternode list
+    fn get_protx_diff(&self, base_block: u32, block: u32) -> Result<json::MasternodeListDiff> {
+        let mut args = ["diff".into(), into_json(base_block)?, into_json(block)?];
+        self.call::<json::MasternodeListDiff>("protx", handle_defaults(&mut args, &[null()]))
+    }
 
 }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1244,6 +1244,12 @@ pub trait RpcApi: Sized {
         self.call::<bool>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Checks which quorums the given masternode is a member of
+    fn get_quorum_memberof(&self, pro_tx_hash: &str, scan_quorums_count: Option<u8>) -> Result<json::QuorumMemberOfResult> {
+        let mut args = ["memberof".into(), into_json(pro_tx_hash)?, opt_into_json(scan_quorums_count)?];
+        self.call::<json::QuorumMemberOfResult>("quorum", handle_defaults(&mut args, &[null()]))
+}
+
 }
 
 /// Client implements a JSON-RPC client for the Dash Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1248,7 +1248,19 @@ pub trait RpcApi: Sized {
     fn get_quorum_memberof(&self, pro_tx_hash: &str, scan_quorums_count: Option<u8>) -> Result<json::QuorumMemberOfResult> {
         let mut args = ["memberof".into(), into_json(pro_tx_hash)?, opt_into_json(scan_quorums_count)?];
         self.call::<json::QuorumMemberOfResult>("quorum", handle_defaults(&mut args, &[null()]))
-}
+    }
+
+    /// Returns quorum rotation information
+    fn get_quorum_rotationinfo(&self, block_request_hash: &str, extra_share: Option<bool>, base_block_hash: Option<&str>) -> Result<json::QuorumRotationInfo> {
+        let mut args = ["rotationinfo".into(), into_json(block_request_hash)?, opt_into_json(extra_share)?, opt_into_json(base_block_hash)?];
+        self.call::<json::QuorumRotationInfo>("quorum", handle_defaults(&mut args, &[false.into(), "".into(), null()]))
+    }
+
+    /// Returns information about the quorum that would/should sign a request
+    fn get_quorum_selectquorum(&self, llmq_type: u8, id: &str) -> Result<json::SelectQuorumResult> {
+        let mut args = ["selectquorum".into(), into_json(llmq_type)?, into_json(id)?];
+        self.call::<json::SelectQuorumResult>("quorum", handle_defaults(&mut args, &[null()]))
+    }
 
 }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1203,22 +1203,28 @@ pub trait RpcApi: Sized {
     // -------------------------- Quorum -------------------------------
 
     /// Returns a list of on-chain quorums
-    fn get_quorum_list(&self, count: Option<&str>) -> Result<HashMap<String, Vec<String>>> {
+    fn get_quorum_list(&self, count: Option<u32>) -> Result<json::QuorumListResult> {
             let mut args = ["list".into(), opt_into_json(count)?];
-            self.call::<HashMap<String, Vec<String>>>("quorum", handle_defaults(&mut args, &["1".into(), null()]))
+            self.call::<json::QuorumListResult>("quorum", handle_defaults(&mut args, &[1.into(), null()]))
     }
 
     /// Returns information about a specific quorum
-    fn get_quorum_info(&self, llmq_type: &str, quorum_hash: &str, include_sk_share: Option<bool>) -> Result<json::QuorumInfoResult> {
+    fn get_quorum_info(&self, llmq_type: u32, quorum_hash: &str, include_sk_share: Option<bool>) -> Result<json::QuorumInfoResult> {
             let mut args = ["info".into(), into_json(llmq_type)?, into_json(quorum_hash)?, opt_into_json(include_sk_share)?];
             self.call::<json::QuorumInfoResult>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
     /// Returns the status of the current DKG process
-    fn get_quorum_dkgstatus(&self, detail_level: Option<&str>) -> Result<json::QuorumDKGStatus> {
+    fn get_quorum_dkgstatus(&self, detail_level: Option<u32>) -> Result<json::QuorumDKGStatus> {
            let mut args = ["dkgstatus".into(), opt_into_json(detail_level)?];
-           self.call::<json::QuorumDKGStatus>("quorum", handle_defaults(&mut args, &["0".into(), null()]))
+           self.call::<json::QuorumDKGStatus>("quorum", handle_defaults(&mut args, &[0.into(), null()]))
     }  
+
+    /// Requests threshold-signing for a message.
+    fn get_quorum_sign(&self, llmq_type: u32, id: &str, msg_hash: &str, quorum_hash: Option<&str>, submit: Option<bool>) -> Result<json::QuorumSignResult> {
+            let mut args = ["sign".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?, opt_into_json(quorum_hash)?, opt_into_json(submit)?];
+            self.call::<json::QuorumSignResult>("quorum", handle_defaults(&mut args, &[null()]))
+    }
 
 
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1289,6 +1289,12 @@ pub trait RpcApi: Sized {
             self.call::<json::ProTxList>("protx", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Creates a ProRegTx referencing an existing collateral and and sends it to the network
+    fn get_protx_register(&self, collateral_hash: &str, collateral_index: u32, ip_and_port: &str, owner_address: &str, operator_pub_key: &str, voting_address: &str, operator_reward: u32, payout_address: &str, fee_source_address: Option<&str>, submit: Option<bool>) -> Result<json::ProRegTxHash> {
+        let mut args = ["register".into(), into_json(collateral_hash)?, into_json(collateral_index)?, into_json(ip_and_port)?, into_json(owner_address)?, into_json(operator_pub_key)?, into_json(voting_address)?, into_json(operator_reward)?, into_json(payout_address)?, opt_into_json(fee_source_address)?, opt_into_json(submit)?];
+        self.call::<json::ProRegTxHash>("protx", handle_defaults(&mut args, &[null()]))
+}
+
 }
 
 /// Client implements a JSON-RPC client for the Dash Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1262,6 +1262,13 @@ pub trait RpcApi: Sized {
         self.call::<json::SelectQuorumResult>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Tests if a quorum signature is valid for a request id and a message hash
+    fn get_quorum_verify(&self, llmq_type: u8, id: &str, msg_hash: &str, signature: &str, quorum_hash: Option<&str>, sign_height: Option<u32>) -> Result<bool> {
+            let mut args = ["verify".into(), into_json(llmq_type)?, into_json(id)?, into_json(msg_hash)?, into_json(signature)?, opt_into_json(quorum_hash)?, opt_into_json(sign_height)?];
+            self.call::<bool>("quorum", handle_defaults(&mut args, &[null()]))
+    }
+
+
 }
 
 /// Client implements a JSON-RPC client for the Dash Core daemon or compatible APIs.

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1293,7 +1293,13 @@ pub trait RpcApi: Sized {
     fn get_protx_register(&self, collateral_hash: &str, collateral_index: u32, ip_and_port: &str, owner_address: &str, operator_pub_key: &str, voting_address: &str, operator_reward: u32, payout_address: &str, fee_source_address: Option<&str>, submit: Option<bool>) -> Result<json::ProRegTxHash> {
         let mut args = ["register".into(), into_json(collateral_hash)?, into_json(collateral_index)?, into_json(ip_and_port)?, into_json(owner_address)?, into_json(operator_pub_key)?, into_json(voting_address)?, into_json(operator_reward)?, into_json(payout_address)?, opt_into_json(fee_source_address)?, opt_into_json(submit)?];
         self.call::<json::ProRegTxHash>("protx", handle_defaults(&mut args, &[null()]))
-}
+    }
+
+    /// Creates and funds a ProRegTx with the 1,000 DASH necessary for a masternode and then sends it to the network
+    fn get_protx_register_fund(&self, collateral_address: &str, ip_and_port: &str, owner_address: &str, operator_pub_key: &str, voting_address: &str, operator_reward: u32, payout_address: &str, fund_address: Option<&str>, submit: Option<bool>) -> Result<json::ProRegTxHash> {
+        let mut args = ["register_fund".into(), into_json(collateral_address)?, into_json(ip_and_port)?, into_json(owner_address)?, into_json(operator_pub_key)?, into_json(voting_address)?, into_json(operator_reward)?, into_json(payout_address)?, opt_into_json(fund_address)?, opt_into_json(submit)?];
+        self.call::<json::ProRegTxHash>("protx", handle_defaults(&mut args, &[null()]))
+    }
 
 }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1214,6 +1214,11 @@ pub trait RpcApi: Sized {
             self.call::<json::QuorumInfoResult>("quorum", handle_defaults(&mut args, &[null()]))
     }
 
+    /// Returns the status of the current DKG process
+    fn get_quorum_dkgstatus(&self) -> Result<json::QuorumDKGStatus> {
+           self.call::<json::QuorumDKGStatus>("quorum", &["dkgstatus".into(), "2".into()])
+    }  
+
 
 }
 

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -1215,8 +1215,9 @@ pub trait RpcApi: Sized {
     }
 
     /// Returns the status of the current DKG process
-    fn get_quorum_dkgstatus(&self) -> Result<json::QuorumDKGStatus> {
-           self.call::<json::QuorumDKGStatus>("quorum", &["dkgstatus".into(), "2".into()])
+    fn get_quorum_dkgstatus(&self, detail_level: Option<&str>) -> Result<json::QuorumDKGStatus> {
+           let mut args = ["dkgstatus".into(), opt_into_json(detail_level)?];
+           self.call::<json::QuorumDKGStatus>("quorum", handle_defaults(&mut args, &["0".into(), null()]))
     }  
 
 

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -223,6 +223,8 @@ fn main() {
     test_get_quorum_info(&cl);
     test_get_quorum_dkgstatus(&cl);
     test_get_quorum_sign(&cl);
+    test_get_quorum_getrecsig(&cl);
+    test_get_quorum_hasrecsig(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1211,4 +1213,8 @@ fn test_get_quorum_sign(cl: &Client) {
 
 fn test_get_quorum_getrecsig(cl: &Client) {
     let quorum_dkgstatus = rpc.get_quorum_getrecsig(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
+}
+
+fn test_get_quorum_hasrecsig(cl: &Client) {
+    let quorum_dkgstatus = rpc.get_quorum_hasrecsig(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -225,6 +225,7 @@ fn main() {
     test_get_quorum_sign(&cl);
     test_get_quorum_getrecsig(&cl);
     test_get_quorum_hasrecsig(&cl);
+    test_get_quorum_isconflicting(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1212,9 +1213,13 @@ fn test_get_quorum_sign(cl: &Client) {
 }
 
 fn test_get_quorum_getrecsig(cl: &Client) {
-    let quorum_dkgstatus = rpc.get_quorum_getrecsig(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
+    let quorum_getrecsig = rpc.get_quorum_getrecsig(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
 }
 
 fn test_get_quorum_hasrecsig(cl: &Client) {
-    let quorum_dkgstatus = rpc.get_quorum_hasrecsig(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
+    let quorum_hasrecsig = rpc.get_quorum_hasrecsig(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
+}
+
+fn test_get_quorum_isconflicting(cl: &Client) {
+    let quorum_isconflicting = rpc.get_quorum_isconflicting(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -222,6 +222,7 @@ fn main() {
     test_get_quorum_list(&cl);
     test_get_quorum_info(&cl);
     test_get_quorum_dkgstatus(&cl);
+    test_get_quorum_sign(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1202,4 +1203,8 @@ fn test_get_quorum_dkgstatus(cl: &Client) {
     assert!(quorum_dkgstatus.session.len() >= 0);
     assert!(quorum_dkgstatus.quorum_connections.len() >= 0);
     assert!(quorum_dkgstatus.minable_commitments.len() >= 0);
+}
+
+fn test_get_quorum_sign(cl: &Client) {
+    let quorum_dkgstatus = rpc.get_quorum_sign(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239", None, None).unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -231,6 +231,7 @@ fn main() {
     test_get_quorum_selectquorum(&cl);
     test_get_quorum_verify(&cl);
     test_get_protx_diff(&cl);
+    test_get_protx_info(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1248,4 +1249,10 @@ fn test_get_quorum_verify(cl: &Client) {
 
 fn test_get_protx_diff(cl: &Client) {
     let protx_diff = rpc.get_protx_diff(75000, 76000).unwrap();
+}
+
+fn test_get_protx_info(cl: &Client) {
+    let protx_info = rpc.get_protx_info("000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f").unwrap();
+    assert!(protx_info.collateralIndex >= 0);
+    assert!(protx_info.operatorReward >= 0);
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -1197,7 +1197,7 @@ fn test_get_quorum_info(cl: &Client) {
 }
 
 fn test_get_quorum_dkgstatus(cl: &Client) {
-    let quorum_dkgstatus = rpc.get_quorum_dkgstatus().unwrap();
+    let quorum_dkgstatus = rpc.get_quorum_dkgstatus(None).unwrap();
     assert!(quorum_dkgstatus.time >= 0);
     assert!(quorum_dkgstatus.session.len() >= 0);
     assert!(quorum_dkgstatus.quorum_connections.len() >= 0);

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -212,13 +212,15 @@ fn main() {
     test_disconnect_node(&cl);
     test_add_ban(&cl);
     test_set_network_active(&cl);
-    test_stop(cl);
-    test_get_masternode_count(cl);
-    test_get_masternode_list(cl);
-    test_get_masternode_outputs(cl);
-    test_get_masternode_payments(cl);
-    test_get_masternode_status(cl);
-    test_get_masternode_winners(cl);
+    test_stop(&cl);
+    test_get_masternode_count(&cl);
+    test_get_masternode_list(&cl);
+    test_get_masternode_outputs(&cl);
+    test_get_masternode_payments(&cl);
+    test_get_masternode_status(&cl);
+    test_get_masternode_winners(&cl);
+    test_get_quorum_list(&cl);
+    test_get_quorum_info(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1177,4 +1179,16 @@ fn test_get_masternode_status(cl: &Client) {
 
 fn test_get_masternode_winners(cl: &Client) {
     let masternode_winners = rpc.get_masternode_winners(None, None).unwrap();
+}
+
+
+// ---------------------- Quorum RPC tests---------------------
+
+fn test_get_quorum_list(cl: &Client) {
+    let quorum_list = rpc.get_quorum_list(Some("1")).unwrap();
+}
+
+fn test_get_quorum_info(cl: &Client) {
+    let quorum_info = rpc.get_quorum_info("1", "0000000002fda1c422902234398d0721cb58e465d8046c8112376914ef30c6fe", None).unwrap();
+    assert!(quorum_info.height > 0);
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -233,6 +233,7 @@ fn main() {
     test_get_protx_diff(&cl);
     test_get_protx_info(&cl);
     test_get_protx_list(&cl);
+    test_get_protx_register(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1260,4 +1261,8 @@ fn test_get_protx_info(cl: &Client) {
 
 fn test_get_protx_list(cl: &Client) {
     let protx_list = rpc.get_protx_list(Some("valid"), Some(true), Some(7090)).unwrap();
+}
+
+fn test_get_protx_register(cl: &Client) {
+    llet protx_register = rpc.get_protx_register("8b2eab3413abb6e04d17d1defe2b71039ba6b6f72ea1e5dab29bb10e7b745948", 1, "2.3.4.5:2345", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", "88d719278eef605d9c19037366910b59bc28d437de4a8db4d76fda6d6985dbdf10404fb9bb5cd0e8c22f4a914a6c5566", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", 5, "yjJJLkYDUN6X8gWjXbCoKEXoiLeKxxMMRt", None, Some(false)).unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -234,6 +234,7 @@ fn main() {
     test_get_protx_info(&cl);
     test_get_protx_list(&cl);
     test_get_protx_register(&cl);
+    test_get_protx_register_fund(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1264,5 +1265,9 @@ fn test_get_protx_list(cl: &Client) {
 }
 
 fn test_get_protx_register(cl: &Client) {
-    llet protx_register = rpc.get_protx_register("8b2eab3413abb6e04d17d1defe2b71039ba6b6f72ea1e5dab29bb10e7b745948", 1, "2.3.4.5:2345", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", "88d719278eef605d9c19037366910b59bc28d437de4a8db4d76fda6d6985dbdf10404fb9bb5cd0e8c22f4a914a6c5566", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", 5, "yjJJLkYDUN6X8gWjXbCoKEXoiLeKxxMMRt", None, Some(false)).unwrap();
+    let protx_register = rpc.get_protx_register("8b2eab3413abb6e04d17d1defe2b71039ba6b6f72ea1e5dab29bb10e7b745948", 1, "2.3.4.5:2345", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", "88d719278eef605d9c19037366910b59bc28d437de4a8db4d76fda6d6985dbdf10404fb9bb5cd0e8c22f4a914a6c5566", "yNLuVTXJbjbxgrQX5LSMi7hV19We8hT2d6", 5, "yjJJLkYDUN6X8gWjXbCoKEXoiLeKxxMMRt", None, Some(false)).unwrap();
+}
+
+fn test_get_protx_register_fund(cl: &Client) {
+    let protx_register_fund = rpc.get_protx_register_fund("yakx4mMRptKhgfjedNzX5FGQq7kSSBF2e7", "3.4.5.6:3456", "yURczr3qY31xkQZfFu8eZvKz19eAEPQxsd", "0e02146e9c34cfbcb3f3037574a1abb35525e2ca0c3c6901dbf82ac591e30218d1711223b7ca956edf39f3d984d06d51", "yURczr3qY31xkQZfFu8eZvKz19eAEPQxsd", 5, "yUYTxqjpCfAAK4vgxXtBPywRBtZqsxN7Vy", Some("yRMFHxcJ2aS2vfo5whhE2Gg73dfQVm8LAF"), Some(false)).unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -226,6 +226,7 @@ fn main() {
     test_get_quorum_getrecsig(&cl);
     test_get_quorum_hasrecsig(&cl);
     test_get_quorum_isconflicting(&cl);
+    test_get_quorum_memberof(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1222,4 +1223,9 @@ fn test_get_quorum_hasrecsig(cl: &Client) {
 
 fn test_get_quorum_isconflicting(cl: &Client) {
     let quorum_isconflicting = rpc.get_quorum_isconflicting(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
+}
+
+fn test_get_quorum_memberof(cl: &Client) {
+    let quorum_memberof = rpc.get_quorum_memberof("39c07d2c9c6d0ead56f52726b63c15e295cb5c3ecf7fe1fefcfb23b2e3cfed1f", Some(1)).unwrap();
+    assert!(quorum_memberof[0].height > 0);
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -229,6 +229,7 @@ fn main() {
     test_get_quorum_memberof(&cl);
     test_get_quorum_rotationinfo(&cl);
     test_get_quorum_selectquorum(&cl);
+    test_get_quorum_verify(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1238,4 +1239,8 @@ fn test_get_quorum_rotationinfo(cl: &Client) {
 
 fn test_get_quorum_selectquorum(cl: &Client) {
     let quorum_selectquorum = rpc.get_quorum_selectquorum(1, "b95205c3bba72e9edfbe7380ec91fe5a97e16a189e28f39b03c6822757ad1a34").unwrap();
+}
+
+fn test_get_quorum_verify(cl: &Client) {
+    let quorum_verify = rpc.get_quorum_verify(1, "2ceeaa7ff20de327ef65b14de692199d15b67b9458d0ded7d68735cce98dd039", "8b5174d0e95b5642ebec23c3fe8f0bbf8f6993502f4210322871bba0e818ff3b", "99cf2a0deb08286a2d1ffdd2564b35522fd748c8802e561abed330dea20df5cb5a5dffeddbe627ea32cb36de13d5b4a516fdfaebae9886b2f7969a5d112416cf8d1983ebcbf1463a64f7522505627e08b9c76c036616fbb1649271a2773a1653", Some("000000583a348d1a0a5f753ef98e6a69f9bcd9b27919f10eb1a1c3edb6c79182"), None).unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -1208,3 +1208,7 @@ fn test_get_quorum_dkgstatus(cl: &Client) {
 fn test_get_quorum_sign(cl: &Client) {
     let quorum_dkgstatus = rpc.get_quorum_sign(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239", None, None).unwrap();
 }
+
+fn test_get_quorum_getrecsig(cl: &Client) {
+    let quorum_dkgstatus = rpc.get_quorum_getrecsig(1, "abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234", "51c11d287dfa85aef3eebb5420834c8e443e01d15c0b0a8e397d67e2e51aa239").unwrap();
+}

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -227,6 +227,8 @@ fn main() {
     test_get_quorum_hasrecsig(&cl);
     test_get_quorum_isconflicting(&cl);
     test_get_quorum_memberof(&cl);
+    test_get_quorum_rotationinfo(&cl);
+    test_get_quorum_selectquorum(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1228,4 +1230,12 @@ fn test_get_quorum_isconflicting(cl: &Client) {
 fn test_get_quorum_memberof(cl: &Client) {
     let quorum_memberof = rpc.get_quorum_memberof("39c07d2c9c6d0ead56f52726b63c15e295cb5c3ecf7fe1fefcfb23b2e3cfed1f", Some(1)).unwrap();
     assert!(quorum_memberof[0].height > 0);
+}
+
+fn test_get_quorum_rotationinfo(cl: &Client) {
+    let quorum_rotationinfo = rpc.get_quorum_rotationinfo("0000012197b7ca6360af3756c6a49c217dbbdf8b595fd55e0fcef7ffcd546044", None, None).unwrap();
+}
+
+fn test_get_quorum_selectquorum(cl: &Client) {
+    let quorum_selectquorum = rpc.get_quorum_selectquorum(1, "b95205c3bba72e9edfbe7380ec91fe5a97e16a189e28f39b03c6822757ad1a34").unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -232,6 +232,7 @@ fn main() {
     test_get_quorum_verify(&cl);
     test_get_protx_diff(&cl);
     test_get_protx_info(&cl);
+    test_get_protx_list(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1255,4 +1256,8 @@ fn test_get_protx_info(cl: &Client) {
     let protx_info = rpc.get_protx_info("000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f").unwrap();
     assert!(protx_info.collateralIndex >= 0);
     assert!(protx_info.operatorReward >= 0);
+}
+
+fn test_get_protx_list(cl: &Client) {
+    let protx_list = rpc.get_protx_list(Some("valid"), Some(true), Some(7090)).unwrap();
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -221,6 +221,7 @@ fn main() {
     test_get_masternode_winners(&cl);
     test_get_quorum_list(&cl);
     test_get_quorum_info(&cl);
+    test_get_quorum_dkgstatus(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1189,6 +1190,16 @@ fn test_get_quorum_list(cl: &Client) {
 }
 
 fn test_get_quorum_info(cl: &Client) {
-    let quorum_info = rpc.get_quorum_info("1", "0000000002fda1c422902234398d0721cb58e465d8046c8112376914ef30c6fe", None).unwrap();
+    let quorum_info = rpc.get_quorum_info("1", "000000000c9eddd5d2a707281b7e30d5aac974dac600ff10f01937e1ca36066f", None).unwrap();
     assert!(quorum_info.height > 0);
+    assert!(quorum_info.quorum_index >= 0);
+    assert!(quorum_info.members.len() >= 0);
+}
+
+fn test_get_quorum_dkgstatus(cl: &Client) {
+    let quorum_dkgstatus = rpc.get_quorum_dkgstatus().unwrap();
+    assert!(quorum_dkgstatus.time >= 0);
+    assert!(quorum_dkgstatus.session.len() >= 0);
+    assert!(quorum_dkgstatus.quorum_connections.len() >= 0);
+    assert!(quorum_dkgstatus.minable_commitments.len() >= 0);
 }

--- a/integration_test/src/main.rs
+++ b/integration_test/src/main.rs
@@ -230,6 +230,7 @@ fn main() {
     test_get_quorum_rotationinfo(&cl);
     test_get_quorum_selectquorum(&cl);
     test_get_quorum_verify(&cl);
+    test_get_protx_diff(&cl);
 }
 
 fn test_get_network_info(cl: &Client) {
@@ -1243,4 +1244,8 @@ fn test_get_quorum_selectquorum(cl: &Client) {
 
 fn test_get_quorum_verify(cl: &Client) {
     let quorum_verify = rpc.get_quorum_verify(1, "2ceeaa7ff20de327ef65b14de692199d15b67b9458d0ded7d68735cce98dd039", "8b5174d0e95b5642ebec23c3fe8f0bbf8f6993502f4210322871bba0e818ff3b", "99cf2a0deb08286a2d1ffdd2564b35522fd748c8802e561abed330dea20df5cb5a5dffeddbe627ea32cb36de13d5b4a516fdfaebae9886b2f7969a5d112416cf8d1983ebcbf1463a64f7522505627e08b9c76c036616fbb1649271a2773a1653", Some("000000583a348d1a0a5f753ef98e6a69f9bcd9b27919f10eb1a1c3edb6c79182"), None).unwrap();
+}
+
+fn test_get_protx_diff(cl: &Client) {
+    let protx_diff = rpc.get_protx_diff(75000, 76000).unwrap();
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2105,6 +2105,20 @@ pub struct MasternodeStatus {
 
 // --------------------------- Quorum -------------------------------
 
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct QuorumHash(
+    #[serde(with = "::serde_hex")]
+    pub Vec<u8>
+);
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct QuorumListResult {
+    pub llmq_50_60: Option<Vec<QuorumHash>>,
+    pub llmq_400_60: Option<Vec<QuorumHash>>,
+    pub llmq_400_85: Option<Vec<QuorumHash>>,
+    pub llmq_100_67: Option<Vec<QuorumHash>>,
+}
+
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -2125,8 +2139,7 @@ pub struct QuorumInfoResult {
     pub height: u32,
     #[serde(rename = "type")]
     pub quorum_type: String,
-    #[serde(with = "::serde_hex")]
-    pub quorum_hash: Vec<u8>,
+    pub quorum_hash: QuorumHash,
     pub quorum_index: u32,
     #[serde(with = "::serde_hex")]
     pub mined_block: Vec<u8>,
@@ -2157,8 +2170,7 @@ pub enum MemberDetail{
 #[serde(rename_all = "camelCase")]
 pub struct QuorumSessionStatus {
     pub llmq_type: u32,
-    #[serde(default, with = "::serde_hex")]
-    pub quorum_hash: Vec<u8>,
+    pub quorum_hash: QuorumHash,
     pub quorum_height: u32,
     pub phase: u8,
     pub sent_contributions: bool,
@@ -2240,6 +2252,30 @@ pub struct QuorumDKGStatus {
     pub session: Vec<QuorumSession>,
     pub quorum_connections: Vec<QuorumConnection>,
     pub minable_commitments: Vec<QuorumMinableCommitments>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumSignature {
+    pub llmq_type: u8,
+    #[serde(with = "::serde_hex")]
+    pub quorum_hash: Vec<u8>,
+    pub quorum_member: Option<u8>,
+    #[serde(with = "::serde_hex")]
+    pub id: Vec<u8>,
+    #[serde(with = "::serde_hex")]
+    pub msg_hash: Vec<u8>,
+    #[serde(with = "::serde_hex")]
+    pub sign_hash: Vec<u8>,
+    #[serde(with = "::serde_hex")]
+    pub signature: Vec<u8>,
+}
+
+#[serde(untagged)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub enum QuorumSignResult{
+    QuorumSignStatus(bool),
+    QuorumSignSignatureShare(QuorumSignature),
 }
 
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2184,8 +2184,7 @@ pub struct QuorumSessionStatus {
     pub received_complaints: MemberDetail,
     pub received_justifications: MemberDetail,
     pub received_premature_commitments: MemberDetail,
-    #[serde(default, with = "::serde_hex::opt")]
-    pub all_members: Option<Vec<u8>>,
+    pub all_members: Option<Vec<QuorumHash>>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1985,6 +1985,12 @@ impl<'a> serde::Serialize for PubKeyOrAddress<'a> {
 // --------------------------- Masternode -------------------------------
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct ProTxHash(
+    #[serde(with = "::serde_hex")]
+    pub Vec<u8>
+);
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct GetMasternodeCountResult {
     pub total: u32,
     pub enabled: u32,
@@ -1993,8 +1999,7 @@ pub struct GetMasternodeCountResult {
 #[serde_as]
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct Masternode {
-    #[serde(rename = "proTxHash", with = "::serde_hex")]
-    pub pro_tx_hash: Vec<u8>,
+    pub pro_tx_hash: ProTxHash,
     #[serde_as(as = "DisplayFromStr")]
     pub address: SocketAddr,
     #[serde_as(as = "Bytes")]
@@ -2029,8 +2034,7 @@ pub struct Payee {
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct MasternodePayment {
-    #[serde(rename = "proTxHash", with = "::serde_hex")]
-    pub pro_tx_hash: Vec<u8>,
+    pub pro_tx_hash: ProTxHash,
     pub amount: u32,
     pub payees: Vec<Payee>,
 }
@@ -2090,8 +2094,7 @@ pub struct MasternodeStatus {
     pub outpoint: dashcore::OutPoint,
     #[serde_as(as = "DisplayFromStr")]
     pub service: SocketAddr,
-    #[serde(rename = "proTxHash", with = "::serde_hex")]
-    pub pro_tx_hash: Vec<u8>,
+    pub pro_tx_hash: ProTxHash,
     #[serde(rename = "collateralHash", with = "::serde_hex")]
     pub collateral_hash: Vec<u8>,
     #[serde(rename = "collateralIndex")]
@@ -2133,8 +2136,7 @@ pub struct QuorumListResult {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuorumMember {
-    #[serde(with = "::serde_hex")]
-    pub pro_tx_hash: Vec<u8>,
+    pub pro_tx_hash: ProTxHash,
     #[serde_as(as = "Bytes")]
     pub pub_key_operator: Vec<u8>,
     pub valid: bool,
@@ -2164,8 +2166,7 @@ pub struct QuorumInfoResult {
 #[serde(rename_all = "camelCase")]
 pub struct QuorumSessionStatusMember {
     pub member_index: u32,
-    #[serde(default, with = "::serde_hex")]
-    pub pro_tx_hash: Vec<u8>,
+    pub pro_tx_hash: ProTxHash,
 }
 
 #[serde(untagged)]
@@ -2211,8 +2212,7 @@ pub struct QuorumSession {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuorumConnectionInfo {
-    #[serde(with = "::serde_hex")]
-    pub pro_tx_hash: Vec<u8>,
+    pub pro_tx_hash: ProTxHash,
     pub connected: bool,
     #[serde_as(as = "DisplayFromStr")]
     pub address: SocketAddr,
@@ -2418,8 +2418,7 @@ pub struct MetaInfo{
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProTxInfo {
-    #[serde(with = "::serde_hex")]
-    pub pro_tx_hash: Vec<u8>,
+    pub pro_tx_hash: ProTxHash,
     #[serde(with = "::serde_hex")]
     pub collateral_hash: Vec<u8>,
     pub collateral_index: u32,
@@ -2432,7 +2431,12 @@ pub struct ProTxInfo {
     pub meta_info: MetaInfo
 }
 
-
+#[serde(untagged)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub enum ProTxList{
+    Hex(Vec<ProTxHash>),
+    Info(Vec<ProTxInfo>)
+}
 
 // Custom deserializer functions.
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2102,6 +2102,40 @@ pub struct MasternodeStatus {
     pub status: String,
 }
 
+// --------------------------- Quorum -------------------------------
+
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumMember {
+    #[serde(with = "::serde_hex")]
+    pub pro_tx_hash: Vec<u8>,
+    #[serde_as(as = "Bytes")]
+    pub pub_key_operator: Vec<u8>,
+    pub valid: bool,
+    #[serde(default, with = "::serde_hex::opt")]
+    pub pub_key_share: Option<Vec<u8>>,
+}
+
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumInfoResult {
+    pub height: u32,
+    #[serde(rename = "type")]
+    pub quorum_type: String,
+    #[serde(with = "::serde_hex")]
+    pub quorum_hash: Vec<u8>,
+    pub quorum_index: u32,
+    #[serde(with = "::serde_hex")]
+    pub mined_block: Vec<u8>,
+    pub members: Vec<QuorumMember>,
+    #[serde_as(as = "Bytes")]
+    pub quorum_public_key: Vec<u8>,
+    #[serde(default, with = "::serde_hex::opt")]
+    pub quorum_secret_share: Option<Vec<u8>>,
+}
+
 // Custom deserializer functions.
 
 /// deserialize_hex_array_opt deserializes a vector of hex-encoded byte arrays.

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2136,6 +2136,104 @@ pub struct QuorumInfoResult {
     pub quorum_secret_share: Option<Vec<u8>>,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumSessionStatusMember {
+    pub member_index: u32,
+    #[serde(default, with = "::serde_hex")]
+    pub pro_tx_hash: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumSessionStatus {
+    pub llmq_type: u32,
+    #[serde(default, with = "::serde_hex")]
+    pub quorum_hash: Vec<u8>,
+    pub quorum_height: u32,
+    pub phase: u8,
+    pub sent_contributions: bool,
+    pub sent_complaint: bool,
+    pub sent_justification: bool,
+    pub sent_premature_commitment: bool,
+    pub aborted: bool,
+    pub bad_members: Vec<u8>,
+    pub we_complain: Vec<u8>,
+    pub received_contributions: QuorumSessionStatusMember,
+    pub received_complaints: Vec<u8>,
+    pub received_justifications: Vec<u8>,
+    pub received_premature_commitments: QuorumSessionStatusMember,
+    #[serde(with = "::serde_hex")]
+    pub all_members: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumSession {
+    pub llmq_type: String,
+    pub quorum_index: u32,
+    pub status: QuorumSessionStatus,
+}
+
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumConnectionInfo {
+    #[serde(with = "::serde_hex")]
+    pub pro_tx_hash: Vec<u8>,
+    pub connected: bool,
+    pub address: Option<SocketAddr>,
+    pub outbound: bool,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumConnection {
+    pub llmq_type: String,
+    pub quorum_index: u32,
+    pub p_quorum_base_block_index: u32,
+    #[serde(with = "::serde_hex")]
+    pub quorum_hash: Vec<u8>,
+    pub pindex_tip: u32,
+    pub quorum_connections: Vec<QuorumConnectionInfo>
+}
+
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumMinableCommitments {
+    pub version: u8,
+    pub llmq_type: u8,
+    #[serde(with = "::serde_hex")]
+    pub quorum_hash: Vec<u8>,
+    pub quorum_index: u32,
+    pub signers_count: u32,
+    #[serde_as(as = "Bytes")]
+    pub signers: Vec<u8>,
+    pub valid_members_count: u32,
+    #[serde_as(as = "Bytes")]
+    pub valid_members: Vec<u8>,
+    #[serde_as(as = "Bytes")]
+    pub quorum_public_key: Vec<u8>,
+    #[serde_as(as = "Bytes")]
+    pub quorum_vvec_hash: Vec<u8>,
+    #[serde_as(as = "Bytes")]
+    pub quorum_sig: Vec<u8>,
+    #[serde_as(as = "Bytes")]
+    pub members_sig: Vec<u8>,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumDKGStatus {
+    pub time: u64,
+    pub time_str: String,
+    pub session: Vec<QuorumSession>,
+    pub quorum_connections: Vec<QuorumConnection>,
+    pub minable_commitments: Vec<QuorumMinableCommitments>,
+}
+
+
 // Custom deserializer functions.
 
 /// deserialize_hex_array_opt deserializes a vector of hex-encoded byte arrays.
@@ -2196,5 +2294,3 @@ where
     }
 )
 }
-
-

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2278,6 +2278,27 @@ pub enum QuorumSignResult{
     QuorumSignSignatureShare(QuorumSignature),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumMemberOf {
+    pub height: u32,
+    #[serde(rename = "type")]
+    pub quorum_type: String,
+    #[serde(with = "::serde_hex")]
+    pub quorum_hash: Vec<u8>,
+    #[serde(with = "::serde_hex")]
+    pub mined_block: Vec<u8>,
+    #[serde(with = "::serde_hex")]
+    pub quorum_public_key: Vec<u8>,
+    pub is_valid_member: bool,
+    pub member_index: u32,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct QuorumMemberOfResult(
+    pub Vec<QuorumMemberOf>
+);
+
 
 // Custom deserializer functions.
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2389,6 +2389,51 @@ enum IntegerOrString<'a> {
     String(&'a str),
 }
 
+// --------------------------- ProTx -------------------------------
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Wallet{
+    pub has_owner_key: bool,
+    pub has_operator_key: bool,
+    pub has_voting_key: bool,
+    pub owns_collateral: bool,
+    pub owns_payee_script: bool,
+    pub owns_operator_reward_script: bool
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetaInfo{
+    #[serde(rename = "lastDSQ")]
+    pub last_dsq: u32,
+    pub mixing_tx_count: u32,
+    pub last_outbound_attempt: u32,
+    pub last_outbound_attempt_elapsed: u32,
+    pub last_outbound_success: u32,
+    pub last_outbound_success_elapsed: u32
+}
+
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProTxInfo {
+    #[serde(with = "::serde_hex")]
+    pub pro_tx_hash: Vec<u8>,
+    #[serde(with = "::serde_hex")]
+    pub collateral_hash: Vec<u8>,
+    pub collateral_index: u32,
+    #[serde_as(as = "Bytes")]
+    pub collateral_address: Vec<u8>,
+    pub operator_reward: u32,
+    pub state: DMNState,
+    pub confirmations: u32,
+    pub wallet: Wallet,
+    pub meta_info: MetaInfo
+}
+
+
+
 // Custom deserializer functions.
 
 /// deserialize_hex_array_opt deserializes a vector of hex-encoded byte arrays.

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2105,6 +2105,13 @@ pub struct MasternodeStatus {
 
 // --------------------------- Quorum -------------------------------
 
+#[serde(untagged)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub enum QuorumType{
+    Integer(u8),
+    String(String),
+}
+
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct QuorumHash(
     #[serde(with = "::serde_hex")]
@@ -2138,7 +2145,7 @@ pub struct QuorumMember {
 pub struct QuorumInfoResult {
     pub height: u32,
     #[serde(rename = "type")]
-    pub quorum_type: String,
+    pub quorum_type: QuorumType,
     pub quorum_hash: QuorumHash,
     pub quorum_index: u32,
     #[serde(with = "::serde_hex")]
@@ -2169,7 +2176,7 @@ pub enum MemberDetail{
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuorumSessionStatus {
-    pub llmq_type: u32,
+    pub llmq_type: QuorumType,
     pub quorum_hash: QuorumHash,
     pub quorum_height: u32,
     pub phase: u8,
@@ -2190,7 +2197,7 @@ pub struct QuorumSessionStatus {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuorumSession {
-    pub llmq_type: String,
+    pub llmq_type: QuorumType,
     pub quorum_index: u32,
     pub status: QuorumSessionStatus,
 }
@@ -2210,7 +2217,7 @@ pub struct QuorumConnectionInfo {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuorumConnection {
-    pub llmq_type: String,
+    pub llmq_type: QuorumType,
     pub quorum_index: u32,
     pub p_quorum_base_block_index: u32,
     pub quorum_hash: QuorumHash,
@@ -2223,7 +2230,7 @@ pub struct QuorumConnection {
 #[serde(rename_all = "camelCase")]
 pub struct QuorumMinableCommitments {
     pub version: u8,
-    pub llmq_type: u8,
+    pub llmq_type: QuorumType,
     pub quorum_hash: QuorumHash,
     pub quorum_index: u32,
     pub signers_count: u32,
@@ -2255,7 +2262,7 @@ pub struct QuorumDKGStatus {
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuorumSignature {
-    pub llmq_type: u8,
+    pub llmq_type: QuorumType,
     pub quorum_hash: QuorumHash,
     pub quorum_member: Option<u8>,
     #[serde(with = "::serde_hex")]
@@ -2280,7 +2287,7 @@ pub enum QuorumSignResult{
 pub struct QuorumMemberOf {
     pub height: u32,
     #[serde(rename = "type")]
-    pub quorum_type: String,
+    pub quorum_type: QuorumType,
     pub quorum_hash: QuorumHash,
     #[serde(with = "::serde_hex")]
     pub mined_block: Vec<u8>,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -24,6 +24,8 @@ extern crate serde_json;
 extern crate serde_with;
 
 use std::collections::HashMap;
+use std::fmt;
+use std::net::{SocketAddr};
 
 use dashcore::consensus::encode;
 use dashcore::hashes::hex::{FromHex, ToHex};
@@ -33,8 +35,7 @@ use dashcore::{Address, Amount, PrivateKey, PublicKey, Script, SignedAmount, Tra
 use serde::de::Error as SerdeError;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr, Bytes};
-use std::fmt;
-use std::net::{SocketAddr};
+
 
 //TODO(stevenroose) consider using a Time type
 
@@ -2144,6 +2145,14 @@ pub struct QuorumSessionStatusMember {
     pub pro_tx_hash: Vec<u8>,
 }
 
+#[serde(untagged)]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub enum MemberDetail{
+    Level0(i32),
+    Level1(Vec<i32>),
+    Level2(Vec<QuorumSessionStatusMember>),
+}
+
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QuorumSessionStatus {
@@ -2157,14 +2166,14 @@ pub struct QuorumSessionStatus {
     pub sent_justification: bool,
     pub sent_premature_commitment: bool,
     pub aborted: bool,
-    pub bad_members: Vec<u8>,
-    pub we_complain: Vec<u8>,
-    pub received_contributions: QuorumSessionStatusMember,
-    pub received_complaints: Vec<u8>,
-    pub received_justifications: Vec<u8>,
-    pub received_premature_commitments: QuorumSessionStatusMember,
-    #[serde(with = "::serde_hex")]
-    pub all_members: Vec<u8>,
+    pub bad_members: MemberDetail,
+    pub we_complain: MemberDetail,
+    pub received_contributions: MemberDetail,
+    pub received_complaints: MemberDetail,
+    pub received_justifications: MemberDetail,
+    pub received_premature_commitments: MemberDetail,
+    #[serde(default, with = "::serde_hex::opt")]
+    pub all_members: Option<Vec<u8>>,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2202,7 +2202,8 @@ pub struct QuorumConnectionInfo {
     #[serde(with = "::serde_hex")]
     pub pro_tx_hash: Vec<u8>,
     pub connected: bool,
-    pub address: Option<SocketAddr>,
+    #[serde_as(as = "DisplayFromStr")]
+    pub address: SocketAddr,
     pub outbound: bool,
 }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -1991,6 +1991,12 @@ pub struct ProTxHash(
 );
 
 #[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+pub struct ProRegTxHash(
+    #[serde(with = "::serde_hex")]
+    pub Vec<u8>
+);
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
 pub struct GetMasternodeCountResult {
     pub total: u32,
     pub enabled: u32,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -2213,8 +2213,7 @@ pub struct QuorumConnection {
     pub llmq_type: String,
     pub quorum_index: u32,
     pub p_quorum_base_block_index: u32,
-    #[serde(with = "::serde_hex")]
-    pub quorum_hash: Vec<u8>,
+    pub quorum_hash: QuorumHash,
     pub pindex_tip: u32,
     pub quorum_connections: Vec<QuorumConnectionInfo>
 }
@@ -2225,8 +2224,7 @@ pub struct QuorumConnection {
 pub struct QuorumMinableCommitments {
     pub version: u8,
     pub llmq_type: u8,
-    #[serde(with = "::serde_hex")]
-    pub quorum_hash: Vec<u8>,
+    pub quorum_hash: QuorumHash,
     pub quorum_index: u32,
     pub signers_count: u32,
     #[serde_as(as = "Bytes")]
@@ -2258,8 +2256,7 @@ pub struct QuorumDKGStatus {
 #[serde(rename_all = "camelCase")]
 pub struct QuorumSignature {
     pub llmq_type: u8,
-    #[serde(with = "::serde_hex")]
-    pub quorum_hash: Vec<u8>,
+    pub quorum_hash: QuorumHash,
     pub quorum_member: Option<u8>,
     #[serde(with = "::serde_hex")]
     pub id: Vec<u8>,
@@ -2284,8 +2281,7 @@ pub struct QuorumMemberOf {
     pub height: u32,
     #[serde(rename = "type")]
     pub quorum_type: String,
-    #[serde(with = "::serde_hex")]
-    pub quorum_hash: Vec<u8>,
+    pub quorum_hash: QuorumHash,
     #[serde(with = "::serde_hex")]
     pub mined_block: Vec<u8>,
     #[serde(with = "::serde_hex")]
@@ -2298,6 +2294,78 @@ pub struct QuorumMemberOf {
 pub struct QuorumMemberOfResult(
     pub Vec<QuorumMemberOf>
 );
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumSnapshot {
+    pub active_quorum_members: Vec<bool>,
+    pub mn_skip_list_mode: u8,
+    pub mn_skip_list: Vec<u8>,
+}
+
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumMasternodeListItem {
+    #[serde(with = "::serde_hex")]
+    pub pro_reg_tx_hash: Vec<u8>,
+    #[serde(with = "::serde_hex")]
+    pub confirmed_hash: Vec<u8>,
+    #[serde_as(as = "DisplayFromStr")]
+    pub service: SocketAddr,
+    #[serde_as(as = "Bytes")]
+    pub pub_key_operator: Vec<u8>,
+    #[serde_as(as = "Bytes")]
+    pub voting_address: Vec<u8>,
+    pub is_valid: bool,
+}
+
+#[serde_as]
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MasternodeListDiff {
+    pub base_block_hash: dashcore::BlockHash,
+    pub block_hash: dashcore::BlockHash,
+    #[serde_as(as = "Bytes")]
+    pub cb_tx_merkle_tree: Vec<u8>,
+    #[serde_as(as = "Bytes")]
+    pub cb_tx: Vec<u8>,
+    #[serde(rename = "deletedMNs")]
+    pub deleted_mns: Vec<QuorumMasternodeListItem>,
+    pub mn_list: Vec<QuorumMasternodeListItem>,
+    pub deleted_quorums: Vec<QuorumMinableCommitments>,
+    pub new_quorums: Vec<QuorumMinableCommitments>,
+    #[serde(rename = "merkleRootMNList", with = "::serde_hex")]
+    pub merkle_root_mn_list: Vec<u8>,
+    #[serde(rename = "merkleRootQuorums", with = "::serde_hex")]
+    pub merkle_root_quorums: Vec<u8>,
+}
+
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuorumRotationInfo {
+    pub extra_share: bool,
+    pub quorum_snapshot_at_h_minus_c: QuorumSnapshot,
+    pub quorum_snapshot_at_h_minus_2c: QuorumSnapshot,
+    pub quorum_snapshot_at_h_minus_3c: QuorumSnapshot,
+    pub mn_list_diff_tip: MasternodeListDiff,
+    pub mn_list_diff_h: MasternodeListDiff,
+    pub mn_list_diff_at_h_minus_c: MasternodeListDiff,
+    pub mn_list_diff_at_h_minus_2c: MasternodeListDiff,
+    pub mn_list_diff_at_h_minus_3c: MasternodeListDiff,
+    pub block_hash_list: Vec<dashcore::BlockHash>,
+    pub quorum_snapshot_list: Vec<QuorumSnapshot>,
+    pub mn_list_diff_list: Vec<MasternodeListDiff>,
+}
+
+
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectQuorumResult {
+    pub quorum_hash: QuorumHash,
+    pub recovery_members: Vec<QuorumHash>
+}
 
 
 // Custom deserializer functions.


### PR DESCRIPTION
This PR introduces the following ProTx RPC calls:

- `protx diff`
- `protx info`
- `protx list`
- `protx register`
- `protx register_fund`